### PR TITLE
feat: Remove misleading `fqbn` key from sketch build profiles

### DIFF
--- a/examples/air-quality-monitoring/sketch/sketch.yaml
+++ b/examples/air-quality-monitoring/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/blink-with-ui/sketch/sketch.yaml
+++ b/examples/blink-with-ui/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/blink/sketch/sketch.yaml
+++ b/examples/blink/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/cloud-blink/sketch/sketch.yaml
+++ b/examples/cloud-blink/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/home-climate-monitoring-and-storage/sketch/sketch.yaml
+++ b/examples/home-climate-monitoring-and-storage/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/keyword-spotting/sketch/sketch.yaml
+++ b/examples/keyword-spotting/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/led-matrix-painter/sketch/sketch.yaml
+++ b/examples/led-matrix-painter/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/mascot-jump-game/sketch/sketch.yaml
+++ b/examples/mascot-jump-game/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/real-time-accelerometer/sketch/sketch.yaml
+++ b/examples/real-time-accelerometer/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/unoq-pin-toggle/sketch/sketch.yaml
+++ b/examples/unoq-pin-toggle/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/vibration-anomaly-detection/sketch/sketch.yaml
+++ b/examples/vibration-anomaly-detection/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:

--- a/examples/weather-forecast/sketch/sketch.yaml
+++ b/examples/weather-forecast/sketch/sketch.yaml
@@ -1,6 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
     libraries:


### PR DESCRIPTION
The dependencies of the examples' sketch components are defined via [build profiles](https://arduino.github.io/arduino-cli/dev/sketch-project-file/#build-profiles) in the sketch project file (`sketch.yaml`).

In addition to dependencies, the general build profile framework allows for specifying the board configuration. The board definition to use with the profile can be defined via the `fqbn` key of the profile. Such `fqbn` keys were present in the build profiles of the examples. It is also possible to specify the FQBN directly when triggering the compilation and upload operations. In this case, the explicitly specified FQBN overrides the one configured in the build profile.

Arduino App CLI (and thus Arduino App Lab) explicitly specifies hard coded FQBNs when it performs compile and upload operations (https://github.com/arduino/arduino-app-cli/pull/12). This means an `fqbn` key in the build profile of an App's sketch has absolutely no effect.

The obvious problem with the presence of `fqbn` keys in the build profiles of examples is that it will lead the advanced user to believe they can configure the FQBN used by App Lab when running Apps created from the examples by modifying the value of the `fqbn` key of the build profile. For example, they might try to make App Lab use the `arduino:zephyr:unoq:flash_mode=flash,wait_linux_boot=no` FQBN in cases where the sketch code is not reliant on the immediate availability of the Linux machine and they do not wish for the execution of the sketch program to be delayed after power on.

Even more confusing is the fact that the `arduino:zephyr:unoq:flash_mode=ram` FQBN used by Arduino App CLI when uploading is different from the FQBN the value of the `fqbn` keys would lead the user to believe is in use (since the default value of the `flash_mode` custom board option is `flash` NOT `ram`, and thus the `arduino:zephyr:unoq` used in the template is equivalent to `arduino:zephyr:unoq:flash_mode=flash`).

Removing the unused `fqbn` keys from the build profiles of the sketches will avoid the chance of them causing confusion to users.

---

This change has already been applied to the new App template: https://github.com/arduino/arduino-app-cli/pull/136

The propagation of the change to the examples was recommended there: https://github.com/arduino/arduino-app-cli/pull/136#pullrequestreview-3540421782