### PR TITLE
chore: remove Arduino_RouterBridge dependency

### DIFF
--- a/examples/air-quality-monitoring/sketch/sketch.yaml
+++ b/examples/air-quality-monitoring/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default

--- a/examples/blink-with-ui/sketch/sketch.yaml
+++ b/examples/blink-with-ui/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default

--- a/examples/blink/sketch/sketch.yaml
+++ b/examples/blink/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default

--- a/examples/cloud-blink/sketch/sketch.yaml
+++ b/examples/cloud-blink/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default

--- a/examples/color-your-leds/sketch/sketch.yaml
+++ b/examples/color-your-leds/sketch/sketch.yaml
@@ -1,13 +1,5 @@
 profiles:
   default:
-    fqbn: arduino:zephyr:unoq
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - Arduino_RPClite (0.2.1)
-      - MsgPack (0.4.2)
-      - DebugLog (0.8.4)
-      - ArxContainer (0.7.0)
-      - ArxTypeTraits (0.3.1)
 default_profile: default

--- a/examples/home-climate-monitoring-and-storage/sketch/sketch.yaml
+++ b/examples/home-climate-monitoring-and-storage/sketch/sketch.yaml
@@ -3,12 +3,6 @@ profiles:
     platforms:
       - platform: arduino:zephyr
     libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
       - Arduino_Modulino (0.7.0)
       - dependency: ArduinoGraphics (1.1.4)
       - dependency: Arduino_HS300x (1.0.0)

--- a/examples/keyword-spotting/sketch/sketch.yaml
+++ b/examples/keyword-spotting/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default

--- a/examples/led-matrix-painter/sketch/sketch.yaml
+++ b/examples/led-matrix-painter/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default

--- a/examples/mascot-jump-game/sketch/sketch.yaml
+++ b/examples/mascot-jump-game/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default

--- a/examples/real-time-accelerometer/sketch/sketch.yaml
+++ b/examples/real-time-accelerometer/sketch/sketch.yaml
@@ -3,12 +3,6 @@ profiles:
     platforms:
       - platform: arduino:zephyr
     libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
       - Arduino_Modulino (0.7.0)
       - dependency: ArduinoGraphics (1.1.4)
       - dependency: Arduino_HS300x (1.0.0)

--- a/examples/unoq-pin-toggle/sketch/sketch.yaml
+++ b/examples/unoq-pin-toggle/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default

--- a/examples/vibration-anomaly-detection/sketch/sketch.yaml
+++ b/examples/vibration-anomaly-detection/sketch/sketch.yaml
@@ -3,12 +3,6 @@ profiles:
     platforms:
       - platform: arduino:zephyr
     libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
       - Arduino_Modulino (0.7.0)
       - dependency: ArduinoGraphics (1.1.4)
       - dependency: Arduino_HS300x (1.0.0)

--- a/examples/weather-forecast/sketch/sketch.yaml
+++ b/examples/weather-forecast/sketch/sketch.yaml
@@ -2,11 +2,4 @@ profiles:
   default:
     platforms:
       - platform: arduino:zephyr
-    libraries:
-      - Arduino_RouterBridge (0.3.0)
-      - dependency: Arduino_RPClite (0.2.1)
-      - dependency: ArxContainer (0.7.0)
-      - dependency: ArxTypeTraits (0.3.2)
-      - dependency: DebugLog (0.8.4)
-      - dependency: MsgPack (0.4.2)
 default_profile: default


### PR DESCRIPTION
In the upcoming release of `arduino:zephyr` core, the `Arduino_RouterBridge` library will be included in the core with the mechanism of `libraryDependencies`, so we should remove it from the profile to allow automatic update.