### PR TITLE
fix: remove unused arduino.js library from gesture booth and smart mi…

### DIFF
--- a/examples/gesture-booth/assets/index.html
+++ b/examples/gesture-booth/assets/index.html
@@ -75,7 +75,6 @@ SPDX-License-Identifier: MPL-2.0
 
     <script src="libs/socket.io.min.js"></script>
     <script src="libs/dotlottie-player.js"></script>
-    <script src="libs/arduino.js"></script>
     <script src="function.js"></script>
     <script src="app.js"></script>
   </body>

--- a/examples/smart-mirror/assets/index.html
+++ b/examples/smart-mirror/assets/index.html
@@ -34,7 +34,6 @@ SPDX-License-Identifier: MPL-2.0
     </div>
 
     <script src="libs/socket.io.min.js"></script>
-    <script src="libs/arduino.js"></script>
     <script src="function.js"></script>
     <script src="app.js"></script>
   </body>


### PR DESCRIPTION
Remove unused arduino.js library from gesture booth and smart mirror examples