### PR TITLE
feat: improve license workflows

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -144,7 +144,7 @@ jobs:
 
           if [ -s "$install_warnings_file" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "#### Errors installing dependencies" >> $GITHUB_STEP_SUMMARY
+            echo "### Errors installing dependencies" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "⚠️ These warnings are non-blocking, but they can make the license scan less complete for the affected environment." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -153,7 +153,7 @@ jobs:
 
           if [ -s "$updated_records_file" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "#### Outdated dependency records" >> $GITHUB_STEP_SUMMARY
+            echo "### Outdated dependency records" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "⚠️ These records changed during \`licensed cache\`. This can reflect dependency version updates, license text changes, or other cached metadata changes. They are non-blocking here, but usually mean the branch did not yet contain the latest cached dependency metadata. Please consider to run \`task license:deps\` locally, then review the changes, commit, and push the updated files." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,7 +1,7 @@
 name: Check licensing information
 description: |
-  This workflow checks that the license headers and files are up to date.
-  It runs on pull requests to ensure that any changes to the codebase maintain the required licensing information.
+  This workflow checks that license headers, REUSE metadata and dependency license records are up to date.
+  It runs on pull requests to ensure that licensing information remains valid and reviewable.
 
 on:
   pull_request:
@@ -13,13 +13,51 @@ jobs:
   check-license-headers:
     runs-on: ubuntu-latest
     env:
-      PYTHON_VERSION: '3.13'
-      TASKFILE_VERSION: 'v3.44.0'
-      TASKFILE_PATH: '/home/runner/go/bin'
+      PYTHON_VERSION: "3.13"
+      TASKFILE_VERSION: "v3.44.0"
+      TASKFILE_PATH: "/home/runner/go/bin"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Validate bricks version is stable
+        run: |
+          VERSION=$(grep 'arduino_app_bricks' requirements.txt | sed -E 's/.*%2F([^/]+)\/.*/\1/')
+          echo "Pinned bricks version: $VERSION"
+          if [[ "$VERSION" =~ (rc|alpha|beta|dev) ]]; then
+            echo "::error::requirements.txt pins a pre-release version ($VERSION). Only stable versions are allowed."
+            exit 1
+          fi
+
+      - name: Install Taskfile
+        run: which task || curl -sSfL https://taskfile.dev/install.sh | sh -s -- -b ${{ env.TASKFILE_PATH }} ${{ env.TASKFILE_VERSION }}
+
+      - name: Check license headers and files
+        run: |
+          export PATH="${{ env.TASKFILE_PATH }}:$PATH"
+          task license:headers > /dev/null 2>&1
+          if git diff --quiet; then
+            echo "License headers are up to date!"
+          else
+            echo "::error::License headers are out of date. Please run 'task license:headers' locally, then commit and push the updated files."
+            exit 1
+          fi
+
+  check-dependency-licenses:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: "3.13"
+      TASKFILE_VERSION: "v3.44.0"
+      TASKFILE_PATH: "/home/runner/go/bin"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -39,19 +77,115 @@ jobs:
         with:
           ruby-version: ruby
 
-      - name: Check license headers and files
+      - name: Install Taskfile
+        run: which task || curl -sSfL https://taskfile.dev/install.sh | sh -s -- -b ${{ env.TASKFILE_PATH }} ${{ env.TASKFILE_VERSION }}
+
+      - name: Check dependency licenses (licensed status)
+        id: licensed
         run: |
-          which task || curl -sSfL https://taskfile.dev/install.sh | sh -s -- -b ${{ env.TASKFILE_PATH }} ${{ env.TASKFILE_VERSION }}
           export PATH="${{ env.TASKFILE_PATH }}:$PATH"
-          if ! task license; then
-            echo "::error::License check failed while running 'task license'. Please run 'task license' locally, review the output, then commit and push the updated files."
-            exit 1
-          fi
-          if git diff --quiet; then
-            echo "License data is up to date!"
+          task license:deps 2>&1 | tee licensed_status.log || true
+
+      - name: Annotate and summarize errors
+        if: always()
+        run: |
+          actual_errors_file=$(mktemp)
+          install_warnings_file=$(mktemp)
+          updated_records_file=$(mktemp)
+
+          awk '
+            function flush() {
+              if (block != "") {
+                print block >> output_file
+                print "" >> output_file
+                block = ""
+              }
+            }
+
+            /^Errors:$/ { in_errors = 1; next }
+            in_errors && /^\* / { flush(); block = $0; next }
+            in_errors && /^[[:space:]]+/ {
+              if (block != "") {
+                block = block "\n" $0
+              }
+              next
+            }
+            in_errors && /^$/ { flush(); next }
+            in_errors { flush(); in_errors = 0 }
+            END { flush() }
+          ' output_file="$actual_errors_file" licensed_status.log
+
+          grep '^::warning::Failed to install requirement \[' licensed_status.log | \
+            sed -E 's/^::warning::Failed to install requirement \[(.*)\] in (.+)$/- `\1` in `\2`/' | \
+            sort -u > "$install_warnings_file" || true
+
+          git diff --name-only -- .licenses | \
+            grep -E '\.dep\.ya?ml$' | \
+            sed -E 's#^\.licenses/##; s#\.dep\.ya?ml$##; s#/#.#g; s#^#- `#; s#$#`#' | \
+            sort -u > "$updated_records_file" || true
+
+          echo "### Licensed Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -s "$actual_errors_file" ]; then
+            echo "::error::Dependency license cache is out of date. Run 'task license:deps' locally, then review the changes, commit, and push the updated files."
+            echo "The following dependency license issues require review:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            awk '
+              BEGIN { RS=""; ORS="\n\n" }
+              NF { print "```text\n" $0 "\n```" }
+            ' "$actual_errors_file" >> $GITHUB_STEP_SUMMARY
           else
-            echo "::error::License headers or dependency records are out of date. Please run 'task license' locally, then commit and push the updated files."
-            echo "Found the following differences:"
-            echo "$(git diff)"
+            echo "No blocking dependency license issues found." >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ -s "$install_warnings_file" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "#### Errors installing dependencies" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Warning: these warnings are non-blocking, but they can make the license scan less complete for the affected environment." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            cat "$install_warnings_file" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ -s "$updated_records_file" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "#### Outdated dependency versions" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Warning: these records changed during \`licensed cache\`. They are non-blocking here, but usually mean the branch did not yet contain the latest cached dependency metadata." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            cat "$updated_records_file" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ -s "$actual_errors_file" ]; then
+            # GitHub workflow commands need escaped newlines, otherwise only the
+            # first line is attached to the annotation and the rest is plain log output.
+            awk '
+              function escape(text, escaped) {
+                escaped = text
+                gsub(/%/, "%25", escaped)
+                gsub(/\r/, "%0D", escaped)
+                gsub(/\n/, "%0A", escaped)
+                return escaped
+              }
+
+              function flush() {
+                if (block != "") {
+                  print "::error::" escape(block)
+                  block = ""
+                }
+              }
+
+              /^\* / { flush(); block = $0; next }
+              /^[[:space:]]+/ {
+                if (block != "") {
+                  block = block "\n" $0
+                }
+                next
+              }
+              /^$/ { flush(); next }
+              END { flush() }
+            ' "$actual_errors_file"
+
             exit 1
           fi

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -129,30 +129,30 @@ jobs:
 
           if [ -s "$actual_errors_file" ]; then
             echo "::error::Dependency license cache is out of date. Run 'task license:deps' locally, then review the changes, commit, and push the updated files."
-            echo "The following dependency license issues require review:" >> $GITHUB_STEP_SUMMARY
+            echo "❌ The following dependency license issues require review:" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             awk '
               BEGIN { RS=""; ORS="\n\n" }
               NF { print "```text\n" $0 "\n```" }
             ' "$actual_errors_file" >> $GITHUB_STEP_SUMMARY
           else
-            echo "No blocking dependency license issues found." >> $GITHUB_STEP_SUMMARY
+            echo "✅ No blocking dependency license issues found." >> $GITHUB_STEP_SUMMARY
           fi
 
           if [ -s "$install_warnings_file" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "#### Errors installing dependencies" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Warning: these warnings are non-blocking, but they can make the license scan less complete for the affected environment." >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ These warnings are non-blocking, but they can make the license scan less complete for the affected environment." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             cat "$install_warnings_file" >> $GITHUB_STEP_SUMMARY
           fi
 
           if [ -s "$updated_records_file" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "#### Outdated dependency versions" >> $GITHUB_STEP_SUMMARY
+            echo "#### Updated dependency records" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Warning: these records changed during \`licensed cache\`. They are non-blocking here, but usually mean the branch did not yet contain the latest cached dependency metadata." >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ These records changed during \`licensed cache\`. This can reflect dependency version updates, license text changes, or other cached metadata changes. They are non-blocking here, but usually mean the branch did not yet contain the latest cached dependency metadata. Please consider to run \`task license:deps\` locally, then review the changes, commit, and push the updated files." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             cat "$updated_records_file" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -150,11 +150,14 @@ jobs:
 
           if [ -s "$updated_records_file" ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "#### Updated dependency records" >> $GITHUB_STEP_SUMMARY
+            echo "#### Outdated dependency records" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "⚠️ These records changed during \`licensed cache\`. This can reflect dependency version updates, license text changes, or other cached metadata changes. They are non-blocking here, but usually mean the branch did not yet contain the latest cached dependency metadata. Please consider to run \`task license:deps\` locally, then review the changes, commit, and push the updated files." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             cat "$updated_records_file" >> $GITHUB_STEP_SUMMARY
+            for record in $(cat "$updated_records_file"); do
+              echo "::warning::Dependency record out-of-date: $record"
+            done
           fi
 
           if [ -s "$actual_errors_file" ]; then

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           actual_errors_file=$(mktemp)
           install_warnings_file=$(mktemp)
+          updated_records_raw_file=$(mktemp)
           updated_records_file=$(mktemp)
 
           awk '
@@ -121,8 +122,10 @@ jobs:
 
           git diff --name-only -- .licenses | \
             grep -E '\.dep\.ya?ml$' | \
-            sed -E 's#^\.licenses/##; s#\.dep\.ya?ml$##; s#/#.#g; s#^#- `#; s#$#`#' | \
-            sort -u > "$updated_records_file" || true
+            sed -E 's#^\.licenses/##; s#\.dep\.ya?ml$##; s#/#.#g' | \
+            sort -u > "$updated_records_raw_file" || true
+
+          sed -E 's#^#- `#; s#$#`#' "$updated_records_raw_file" > "$updated_records_file" || true
 
           echo "### Licensed Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -155,9 +158,10 @@ jobs:
             echo "⚠️ These records changed during \`licensed cache\`. This can reflect dependency version updates, license text changes, or other cached metadata changes. They are non-blocking here, but usually mean the branch did not yet contain the latest cached dependency metadata. Please consider to run \`task license:deps\` locally, then review the changes, commit, and push the updated files." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             cat "$updated_records_file" >> $GITHUB_STEP_SUMMARY
-            for record in $(cat "$updated_records_file"); do
+            while IFS= read -r record; do
+              [ -n "$record" ] || continue
               echo "::warning::Dependency record out-of-date: $record"
-            done
+            done < "$updated_records_raw_file"
           fi
 
           if [ -s "$actual_errors_file" ]; then

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Example applications based on Arduino Bricks for the Arduino UNO Q.
 - Run `task license:deps` to refresh cached dependency license records with `licensed`.
 - Run `task license` to execute both checks.
 
-The temporary virtualenvs used by the license tasks are recreated and cleaned up automatically.
+The REUSE virtualenv is recreated and cleaned up automatically. The `.venv` used by `licensed` is kept after the task completes and recreated on the next dependency-license run.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@ Example applications based on Arduino Bricks for the Arduino UNO Q.
 
 ### Requirements
 - Python 3.13+
-- Taskfile (https://taskfile.dev/docs/installation).
+- Taskfile (https://taskfile.dev/docs/installation)
 - `licensed` 5.0.6 (https://github.com/licensee/licensed)
 
 > NOTE: Make sure each requirement is available in PATH.
 
-To update the licenses:
-- Run `task license`
+### Local workflow
+- Run `task license:headers` to update SPDX headers and validate REUSE compliance.
+- Run `task license:deps` to refresh cached dependency license records with `licensed`.
+- Run `task license` to execute both checks.
+
+The temporary virtualenvs used by the license tasks are recreated and cleaned up automatically.

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -7,16 +7,22 @@ vars:
   REUSE_VENV_DIR: '.reuse-venv'
 
 tasks:
-  init:license:
+  license:init-venvs:
     desc: Recreate the environments used by the license tasks
+    internal: true
     cmds:
       - task: license:init-licensed-venv
       - task: license:init-reuse-venv
 
+  init:license:
+    desc: Backward-compatible alias for recreating the environments used by the license tasks
+    cmds:
+      - task: license:init-venvs
+
   init:ci:
     desc: Backward-compatible alias for initializing license environments
     cmds:
-      - task: init:license
+      - task: license:init-venvs
 
   install-bricks:
     desc: Install a specific bricks version (e.g. task install-bricks -- 0.8.0rc2)

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -126,9 +126,14 @@ tasks:
       Update license headers and validate REUSE compliance.
       Uses a dedicated virtualenv for REUSE and cleans it up afterwards.
     cmds:
+      - task: license:init-reuse-venv
       - |
+        cleanup() {
+          rm -rf "{{.REUSE_VENV_DIR}}"
+        }
+        trap cleanup EXIT
+
         status=0
-        task license:init-reuse-venv || status=$?
 
         if [ "$status" -eq 0 ]; then
           # Annotate first-party textual sources without touching vendored
@@ -159,7 +164,6 @@ tasks:
           "{{.REUSE_VENV_DIR}}"/bin/reuse lint || status=$?
         fi
 
-        rm -rf "{{.REUSE_VENV_DIR}}"
         exit "$status"
 
   license:deps:
@@ -171,9 +175,14 @@ tasks:
       In CI, the task installs licensed v{{.LICENSED_VERSION}} with gem after Ruby has been set up by the workflow.
     cmds:
       - task: install:licensed
+      - task: license:init-licensed-venv
       - |
+        cleanup() {
+          rm -rf "{{.LICENSE_VENV_DIR}}"
+        }
+        trap cleanup EXIT
+
         status=0
-        task license:init-licensed-venv || status=$?
 
         if [ "$status" -eq 0 ]; then
           licensed cache || status=$?
@@ -183,7 +192,6 @@ tasks:
           licensed status || status=$?
         fi
 
-        rm -rf "{{.LICENSE_VENV_DIR}}"
         exit "$status"
 
   license:

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -175,7 +175,7 @@ tasks:
   license:deps:
     desc: |
       Check and cache dependency licenses with licensed.
-      Uses a dedicated virtualenv for pip dependency scanning and cleans it up afterwards.
+      Uses a dedicated virtualenv for pip dependency scanning and keeps it after the task completes.
       Requires licensed v{{.LICENSED_VERSION}} for dependency license checking.
       In local environments, install licensed v{{.LICENSED_VERSION}} manually before running this task.
       In CI, the task installs licensed v{{.LICENSED_VERSION}} with gem after Ruby has been set up by the workflow.
@@ -183,11 +183,6 @@ tasks:
       - task: install:licensed
       - task: license:init-licensed-venv
       - |
-        cleanup() {
-          rm -rf "{{.LICENSE_VENV_DIR}}"
-        }
-        trap cleanup EXIT
-
         status=0
 
         if [ "$status" -eq 0 ]; then

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -8,18 +8,10 @@ vars:
 
 tasks:
   init:license:
-    desc: Recreate the environments used by the license task
+    desc: Recreate the environments used by the license tasks
     cmds:
-      - |
-        rm -rf "{{.LICENSE_VENV_DIR}}"
-        python3 -m venv "{{.LICENSE_VENV_DIR}}"
-        "{{.LICENSE_VENV_DIR}}"/bin/pip install --upgrade pip
-        "{{.LICENSE_VENV_DIR}}"/bin/pip install -r requirements.txt
-      - |
-        rm -rf "{{.REUSE_VENV_DIR}}"
-        python3 -m venv "{{.REUSE_VENV_DIR}}"
-        "{{.REUSE_VENV_DIR}}"/bin/pip install --upgrade pip
-        "{{.REUSE_VENV_DIR}}"/bin/pip install reuse=={{.REUSE_VERSION}}
+      - task: license:init-licensed-venv
+      - task: license:init-reuse-venv
 
   init:ci:
     desc: Backward-compatible alias for initializing license environments
@@ -68,7 +60,7 @@ tasks:
 
         echo ""
         echo "============================================================"
-        echo "  ERROR: licensed v{{.LICENSED_VERSION}} is required to run 'task license'."
+        echo "  ERROR: licensed v{{.LICENSED_VERSION}} is required to run 'task license:deps'."
         echo ""
         echo "  Install licensed v{{.LICENSED_VERSION}} manually, make sure it is available in PATH,"
         echo "  and then retry."
@@ -78,38 +70,124 @@ tasks:
         echo "============================================================"
         exit 1
 
-  license:
+  license:init-reuse-venv:
+    desc: Recreate the dedicated virtualenv used by REUSE
+    internal: true
+    cmds:
+      - |
+        rm -rf "{{.REUSE_VENV_DIR}}"
+        python3 -m venv "{{.REUSE_VENV_DIR}}"
+        "{{.REUSE_VENV_DIR}}"/bin/pip install --upgrade pip
+        "{{.REUSE_VENV_DIR}}"/bin/pip install reuse=={{.REUSE_VERSION}}
+
+  license:init-licensed-venv:
+    desc: Recreate the dedicated virtualenv used for licensed dependency scanning
+    internal: true
+    cmds:
+      - |
+        rm -rf "{{.LICENSE_VENV_DIR}}"
+        python3 -m venv "{{.LICENSE_VENV_DIR}}"
+        "{{.LICENSE_VENV_DIR}}"/bin/pip install --upgrade pip -q
+
+        failed_pkgs=()
+        while IFS= read -r line || [ -n "$line" ]; do
+          pkg=$(echo "$line" | sed 's/#.*//;s/^[[:space:]]*//;s/[[:space:]]*$//')
+          [ -z "$pkg" ] && continue
+          "{{.LICENSE_VENV_DIR}}"/bin/pip install -q "$pkg" || failed_pkgs+=("$pkg")
+        done < requirements.txt
+
+        if [ ${#failed_pkgs[@]} -gt 0 ]; then
+          for pkg in "${failed_pkgs[@]}"; do
+            echo "::warning::Failed to install requirement [$pkg] in {{.LICENSE_VENV_DIR}}" >&2
+          done
+        fi
+
+  license:cleanup-reuse-venv:
+    desc: Remove the dedicated REUSE virtualenv
+    internal: true
+    cmds:
+      - rm -rf "{{.REUSE_VENV_DIR}}"
+
+  license:cleanup-licensed-venv:
+    desc: Remove the dedicated licensed virtualenv
+    internal: true
+    cmds:
+      - rm -rf "{{.LICENSE_VENV_DIR}}"
+
+  license:cleanup-venvs:
+    desc: Remove the dedicated license-checking virtualenvs
+    internal: true
+    cmds:
+      - task: license:cleanup-reuse-venv
+      - task: license:cleanup-licensed-venv
+
+  license:headers:
     desc: |
-      Update license headers, validate REUSE compliance and check dependency licenses.
-      Uses a dedicated virtualenv for REUSE and a separate one for pip dependency scanning.
+      Update license headers and validate REUSE compliance.
+      Uses a dedicated virtualenv for REUSE and cleans it up afterwards.
+    cmds:
+      - |
+        status=0
+        task license:init-reuse-venv || status=$?
+
+        if [ "$status" -eq 0 ]; then
+          # Annotate first-party textual sources without touching vendored
+          # libraries, third-party fonts, or binary/media assets that would
+          # otherwise generate .license sidecars.
+          find examples \
+            \( -path '*/python/*' -o -path '*/assets/*' \) \
+            -type f \
+            ! -path '*/assets/libs/*' \
+            ! -path '*/assets/fonts/*' \
+            \( -name '*.py' -o -name '*.js' -o -name '*.css' -o -name '*.html' \) \
+            -exec "{{.REUSE_VENV_DIR}}"/bin/reuse annotate \
+              --skip-unrecognized \
+              --merge-copyrights \
+              --copyright-prefix 'spdx-string-c' \
+              --copyright 'Arduino s.r.l. and/or its affiliated companies' \
+              --exclude-year \
+              --license 'MPL-2.0' \
+              '{}' \
+              ';' || status=$?
+        fi
+
+        if [ "$status" -eq 0 ]; then
+          "{{.REUSE_VENV_DIR}}"/bin/reuse download --all || status=$?
+        fi
+
+        if [ "$status" -eq 0 ]; then
+          "{{.REUSE_VENV_DIR}}"/bin/reuse lint || status=$?
+        fi
+
+        rm -rf "{{.REUSE_VENV_DIR}}"
+        exit "$status"
+
+  license:deps:
+    desc: |
+      Check and cache dependency licenses with licensed.
+      Uses a dedicated virtualenv for pip dependency scanning and cleans it up afterwards.
       Requires licensed v{{.LICENSED_VERSION}} for dependency license checking.
       In local environments, install licensed v{{.LICENSED_VERSION}} manually before running this task.
       In CI, the task installs licensed v{{.LICENSED_VERSION}} with gem after Ruby has been set up by the workflow.
     cmds:
-      - task: init:license
-      - |
-        # Annotate first-party textual sources without touching vendored
-        # libraries, third-party fonts, or binary/media assets that would
-        # otherwise generate .license sidecars.
-        find examples \
-          \( -path '*/python/*' -o -path '*/assets/*' \) \
-          -type f \
-          ! -path '*/assets/libs/*' \
-          ! -path '*/assets/fonts/*' \
-          \( -name '*.py' -o -name '*.js' -o -name '*.css' -o -name '*.html' \) \
-          -exec "{{.REUSE_VENV_DIR}}"/bin/reuse annotate \
-            --skip-unrecognized \
-            --merge-copyrights \
-            --copyright-prefix 'spdx-string-c' \
-            --copyright 'Arduino s.r.l. and/or its affiliated companies' \
-            --exclude-year \
-            --license 'MPL-2.0' \
-            '{}' \
-            ';'
-      - '"{{.REUSE_VENV_DIR}}"/bin/reuse download --all'
-      - '"{{.REUSE_VENV_DIR}}"/bin/reuse lint'
-      - rm -rf "{{.REUSE_VENV_DIR}}"
       - task: install:licensed
       - |
-        licensed cache
-        licensed status
+        status=0
+        task license:init-licensed-venv || status=$?
+
+        if [ "$status" -eq 0 ]; then
+          licensed cache || status=$?
+        fi
+
+        if [ "$status" -eq 0 ]; then
+          licensed status || status=$?
+        fi
+
+        rm -rf "{{.LICENSE_VENV_DIR}}"
+        exit "$status"
+
+  license:
+    desc: Update license headers, validate REUSE compliance and check dependency licenses
+    cmds:
+      - task: license:headers
+      - task: license:deps


### PR DESCRIPTION
Refine license automation in `app-bricks-examples` by separating REUSE and `licensed` responsibilities in both Taskfile and CI, while preserving the repo’s current licensing setup and virtualenv cleanup behavior.

## What's included

- `Taskfile.dist.yml`
  - splits the old monolithic `license` flow into:
    - `license:headers` for REUSE annotations, license downloads and REUSE linting
    - `license:deps` for `licensed cache` + `licensed status`
  - keeps `license` as a backward-compatible aggregate task chaining `license:headers` -> `license:deps`
  - keeps `init:license` and `init:ci` as backward-compatible entry points
  - adds dedicated internal tasks to create and clean up the REUSE and `licensed` virtualenvs separately
  - keeps cleanup of the virtualenvs in this repo after the tasks complete
  - keeps `install:licensed` and updates its messaging to point to `task license:deps`
  - adds non-blocking warnings when requirements cannot be installed in the dependency-scanning venv

- `.github/workflows/license.yml`
  - splits license validation into two jobs:
    - `check-license-headers` for REUSE/header validation
    - `check-dependency-licenses` for `licensed`
  - keeps the stable-version validation for the pinned `arduino_app_bricks` wheel
  - makes dependency-license failures depend on actual `licensed status` errors instead of raw `git diff`
  - adds multiline GitHub Actions annotations for real dependency-license errors
  - adds a detailed step summary with:
    - blocking dependency license issues
    - non-blocking dependency installation warnings
    - non-blocking cached record updates / outdated dependency versions

## Notes

- The existing `.licensed.yml` and `REUSE.toml` configuration are intentionally preserved.
- Warning extraction in CI was made robust for this repo’s `requirements.txt`, including requirement lines with URLs such as:
  - `arduino_app_bricks @ https://...`
- REUSE/header checks still rely on file diffs, while dependency-license checks now rely on the semantic result of `licensed status`.