### PR TITLE
feat: update anomaly detection threshold handling and UI components

### DIFF
--- a/examples/vibration-anomaly-detection/README.md
+++ b/examples/vibration-anomaly-detection/README.md
@@ -50,9 +50,11 @@ The example uses the following Bricks:
    Observe the **Accelerometer Data** chart to see the live vibration waveforms.
 
 5. **Adjust Sensitivity**
-   Use the **Set anomaly score** slider to adjust how sensitive the detector is.
-   - **Lower values (1):** High sensitivity (small vibrations trigger alerts).
-   - **Higher values (10):** Low sensitivity (requires strong, irregular vibrations to trigger).
+   Use the **Set anomaly threshold** slider to adjust how sensitive the detector is.
+   - **Lower values:** High sensitivity (small deviations trigger alerts).
+   - **Higher values:** Low sensitivity (requires stronger, more unusual vibration patterns to trigger).
+   - The threshold is a raw anomaly score, not a 0-1 confidence value; anomaly scores can be greater than 1.0.
+   - The slider covers the common range; use the numeric input if your model produces larger anomaly scores.
 
 6. **Trigger an Anomaly**
    Shake the sensor or attach it to a fan to simulate an anomaly. The "Feedback" section will show a warning, and the event will be logged in "Recent Anomalies".

--- a/examples/vibration-anomaly-detection/assets/app.js
+++ b/examples/vibration-anomaly-detection/assets/app.js
@@ -11,6 +11,10 @@ let errorContainer;
 const recentAnomaliesElement = document.getElementById('recentClassifications');
 let anomalies = [];
 const MAX_RECENT_ANOMALIES = 5;
+const DEFAULT_ANOMALY_THRESHOLD = 1.0;
+const MIN_ANOMALY_THRESHOLD = 0.0;
+const MAX_SLIDER_ANOMALY_THRESHOLD = 20.0;
+const ANOMALY_THRESHOLD_STEP = 0.1;
 
 let hasDataFromBackend = false; // New global flag
 
@@ -127,7 +131,15 @@ function initializeConfidenceSlider() {
     const confidenceInput = document.getElementById('confidenceInput');
     const confidenceResetButton = document.getElementById('confidenceResetButton');
 
-    confidenceSlider.addEventListener('input', updateConfidenceDisplay);
+    confidenceSlider.min = MIN_ANOMALY_THRESHOLD.toString();
+    confidenceSlider.max = MAX_SLIDER_ANOMALY_THRESHOLD.toString();
+    confidenceSlider.step = ANOMALY_THRESHOLD_STEP.toString();
+    confidenceSlider.value = DEFAULT_ANOMALY_THRESHOLD.toString();
+    confidenceInput.min = MIN_ANOMALY_THRESHOLD.toString();
+    confidenceInput.step = ANOMALY_THRESHOLD_STEP.toString();
+    confidenceInput.value = formatThreshold(DEFAULT_ANOMALY_THRESHOLD);
+
+    confidenceSlider.addEventListener('input', () => updateConfidenceDisplay());
     confidenceInput.addEventListener('input', handleConfidenceInputChange);
     confidenceInput.addEventListener('blur', validateConfidenceInput);
     updateConfidenceDisplay();
@@ -139,50 +151,60 @@ function initializeConfidenceSlider() {
     });
 }
 
+function normalizeThreshold(value) {
+    const numericValue = parseFloat(value);
+
+    if (isNaN(numericValue)) {
+        return DEFAULT_ANOMALY_THRESHOLD;
+    }
+
+    return Math.max(MIN_ANOMALY_THRESHOLD, numericValue);
+}
+
+function getSliderValueForThreshold(value) {
+    return Math.min(MAX_SLIDER_ANOMALY_THRESHOLD, normalizeThreshold(value));
+}
+
+function formatThreshold(value) {
+    return normalizeThreshold(value).toFixed(1);
+}
+
 function handleConfidenceInputChange() {
     const confidenceInput = document.getElementById('confidenceInput');
-    const confidenceSlider = document.getElementById('confidenceSlider');
 
-    let value = parseInt(confidenceInput.value, 10);
-
-    if (isNaN(value)) value = 5;
-    if (value < 1) value = 1;
-    if (value > 10) value = 10;
-
-    confidenceSlider.value = value;
-    updateConfidenceDisplay();
+    updateConfidenceDisplay(normalizeThreshold(confidenceInput.value));
 }
 
 function validateConfidenceInput() {
     const confidenceInput = document.getElementById('confidenceInput');
-    let value = parseInt(confidenceInput.value, 10);
+    const value = normalizeThreshold(confidenceInput.value);
 
-    if (isNaN(value)) value = 5;
-    if (value < 1) value = 1;
-    if (value > 10) value = 10;
+    confidenceInput.value = formatThreshold(value);
 
-    confidenceInput.value = value.toFixed(0);
-
-    handleConfidenceInputChange();
+    updateConfidenceDisplay(value);
 }
 
-function updateConfidenceDisplay() {
+function updateConfidenceDisplay(threshold = null) {
     const confidenceSlider = document.getElementById('confidenceSlider');
     const confidenceInput = document.getElementById('confidenceInput');
     const confidenceValueDisplay = document.getElementById('confidenceValueDisplay');
     const sliderProgress = document.getElementById('sliderProgress');
 
-    const value = parseFloat(confidenceSlider.value);
-    socket.emit('override_th', value / 10); // Send scaled confidence to backend (0.1 to 1.0)
-    const percentage = (value - confidenceSlider.min) / (confidenceSlider.max - confidenceSlider.min) * 100;
+    const value = threshold === null ? normalizeThreshold(confidenceSlider.value) : normalizeThreshold(threshold);
+    const sliderValue = getSliderValueForThreshold(value);
 
-    const displayValue = value.toFixed(0);
+    confidenceSlider.value = sliderValue;
+    socket.emit('override_th', value);
+    const percentage = (sliderValue - parseFloat(confidenceSlider.min)) / (parseFloat(confidenceSlider.max) - parseFloat(confidenceSlider.min)) * 100;
+
+    const displayValue = formatThreshold(value);
     confidenceValueDisplay.textContent = displayValue;
 
     if (document.activeElement !== confidenceInput) {
         confidenceInput.value = displayValue;
     }
 
+    confidenceSlider.style.setProperty('--slider-progress', percentage + '%');
     sliderProgress.style.width = percentage + '%';
     confidenceValueDisplay.style.left = percentage + '%';
 }
@@ -191,8 +213,8 @@ function resetConfidence() {
     const confidenceSlider = document.getElementById('confidenceSlider');
     const confidenceInput = document.getElementById('confidenceInput');
 
-    confidenceSlider.value = '5';
-    confidenceInput.value = '5';
+    confidenceSlider.value = DEFAULT_ANOMALY_THRESHOLD.toString();
+    confidenceInput.value = formatThreshold(DEFAULT_ANOMALY_THRESHOLD);
     updateConfidenceDisplay();
 }
 

--- a/examples/vibration-anomaly-detection/assets/index.html
+++ b/examples/vibration-anomaly-detection/assets/index.html
@@ -57,25 +57,25 @@ SPDX-License-Identifier: MPL-2.0
                         <div class="control-group">
                             <div class="control-confidence">
                                 <div style="display: flex; align-items: center; gap: 8px; position: relative;">
-                                    <label id="confidence-label" for="confidenceSlider" class="box-title" style="margin-bottom: 0;">Set anomaly score</label>
+                                    <label id="confidence-label" for="confidenceSlider" class="box-title" style="margin-bottom: 0;">Set anomaly threshold</label>
                                     <img src="./img/info.svg" alt="Info" class="info-btn confidence"/>
                                     <div class="popover">It quantifies how far the current vibration is from the model's 'normal' clusters. <br />
 
-                                        Scores above your threshold are flagged as an anomaly.</div>
+                                        Scores above your threshold are flagged as an anomaly. This value is an anomaly score, not a 0-1 confidence. Use the numeric input for values above the slider range.</div>
                                 </div>
                                 <button id="confidenceResetButton" class="btn-tertiary">
-                                    <input type="number" id="confidenceInput" class="confidence-input" min="1" max="10" step="1" value="5">
+                                    <input type="number" id="confidenceInput" class="confidence-input" min="0" step="0.1" value="1.0">
                                     <img src="img/reset.svg" alt="Reset" class="reset-icon">
                                 </button>
                             </div>
                             <div class="slider-box">
-                                <span class="confidence-limits">1</span>
+                                <span class="confidence-limits">0</span>
                                 <div class="slider-container">
                                     <div class="slider-progress" id="sliderProgress"></div>
-                                    <div class="confidence-value-display" id="confidenceValueDisplay">5</div>
-                                    <input type="range" id="confidenceSlider" min="1" max="10" step="1" value="5">
+                                    <div class="confidence-value-display" id="confidenceValueDisplay">1.0</div>
+                                    <input type="range" id="confidenceSlider" min="0" max="20" step="0.1" value="1.0">
                                 </div>
-                                <span class="confidence-limits">10</span>
+                                <span class="confidence-limits">20+</span>
                             </div>
                         </div>
                     </div>

--- a/examples/vibration-anomaly-detection/assets/style.css
+++ b/examples/vibration-anomaly-detection/assets/style.css
@@ -312,14 +312,20 @@ body {
 
 #confidenceSlider {
     width: 100%;
-    height: 6px;
+    height: 32px;
     border-radius: 3px;
-    background: #DAE3E3;
+    background: linear-gradient(to right, #008184 0%, #008184 var(--slider-progress, 0%), #DAE3E3 var(--slider-progress, 0%), #DAE3E3 100%);
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 100% 6px;
     outline: none;
     -webkit-appearance: none;
     appearance: none;
     position: relative;
-    margin: 20px 0 10px 0;
+    z-index: 2;
+    margin: 8px 0 0 0;
+    cursor: pointer;
+    touch-action: none;
 }
 
 #confidenceSlider::-webkit-slider-thumb {
@@ -331,7 +337,7 @@ body {
     background: #008184;
     cursor: pointer;
     position: relative;
-    bottom: 3px;
+    margin-top: -3px;
     z-index: 2;
 }
 
@@ -339,32 +345,31 @@ body {
     width: 100%;
     height: 6px;
     border-radius: 3px;
-    background: #DAE3E3;
+    background: transparent;
 }
 
 #confidenceSlider::-moz-range-track {
     width: 100%;
     height: 6px;
     border-radius: 3px;
-    background: #DAE3E3;
+    background: transparent;
     border: none;
+}
+
+#confidenceSlider::-moz-range-progress {
+    height: 6px;
+    border-radius: 3px;
+    background: #008184;
 }
 
 .slider-container {
     position: relative;
     width: 100%;
+    min-height: 40px;
 }
 
 .slider-progress {
-    position: absolute;
-    top: 20px;
-    left: 0;
-    height: 6px;
-    background: #008184;
-    border-radius: 3px;
-    pointer-events: none;
-    z-index: 1;
-    transition: width 0.1s ease;
+    display: none;
 }
 
 .confidence-value-display {

--- a/examples/vibration-anomaly-detection/python/main.py
+++ b/examples/vibration-anomaly-detection/python/main.py
@@ -13,8 +13,13 @@ logger = Logger("vibration-detector")
 vibration_detection = VibrationAnomalyDetection(anomaly_detection_threshold=1.0)
 
 def on_override_th(value: float):
-    logger.info(f"Setting new anomaly threshold: {value}")
-    vibration_detection.anomaly_detection_threshold = value
+    try:
+        vibration_detection.anomaly_detection_threshold = value
+    except ValueError as exc:
+        logger.warning(f"Ignoring invalid anomaly threshold {value!r}: {exc}")
+        return
+
+    logger.info(f"Setting new anomaly threshold: {vibration_detection.anomaly_detection_threshold}")
 
 ui = WebUI()
 ui.on_message("override_th", lambda sid, threshold: on_override_th(threshold))


### PR DESCRIPTION
This PR fixes vibration anomaly threshold handling in the example UI/backend. 

The slider now sends the real anomaly threshold instead of dividing by 10, supports scores above 1.0, and remains draggable.

The Python backend validates threshold updates, and the README/UI copy now explains that anomaly scores are raw model scores rather than confidence percentages.