### PR TITLE
fix: ensure story type selection does not block character panel unlocking

### DIFF
--- a/examples/bedtime-story-teller/assets/app.js
+++ b/examples/bedtime-story-teller/assets/app.js
@@ -82,16 +82,25 @@ function handleStoryError(data) {
 
 function unlockAndOpenNext(currentContainer) {
   const nextContainer = currentContainer.nextElementSibling;
-  if (nextContainer && nextContainer.classList.contains('parameter-container')) {
-    if (nextContainer.classList.contains('disabled')) {
-      nextContainer.classList.remove('disabled');
-      const content = nextContainer.querySelector('.parameter-content');
-      const arrow = nextContainer.querySelector('.arrow-icon');
-      if (content.style.display !== 'block') {
-        content.style.display = 'block';
-        arrow.classList.add('rotated');
-      }
+  if (!nextContainer || !nextContainer.classList.contains('parameter-container')) return;
+  if (!nextContainer.classList.contains('disabled')) return;
+
+  nextContainer.classList.remove('disabled');
+
+  // "Story type" is optional, so it must never gate the following section.
+  // Unlock the panel after it (Characters) as soon as Story type becomes available,
+  if (nextContainer.querySelector('.story-type-selections')) {
+    const charactersContainer = nextContainer.nextElementSibling;
+    if (charactersContainer && charactersContainer.classList.contains('parameter-container')) {
+      charactersContainer.classList.remove('disabled');
     }
+  }
+
+  const content = nextContainer.querySelector('.parameter-content');
+  const arrow = nextContainer.querySelector('.arrow-icon');
+  if (content.style.display !== 'block') {
+    content.style.display = 'block';
+    arrow.classList.add('rotated');
   }
 }
 


### PR DESCRIPTION
The "Story type" panel is optional, so it should never block the following "Characters" panel from being unlocked. This PR fixes that by immediately unlocking the Characters panel as soon as Story type becomes available, regardless of whether the user makes any selection in it.
Additionally, refactored unlockAndOpenNext to use early returns instead of nested if blocks for better readability.