### PR TITLE
fix(security): address CodeQL DOM and no-op replace findings

### DIFF
--- a/examples/common/vibration-anomaly-detection/assets/app.js
+++ b/examples/common/vibration-anomaly-detection/assets/app.js
@@ -334,19 +334,17 @@ function renderAnomalies() {
         minute: '2-digit',
         second: '2-digit',
       });
-      const dateString = date
-        .toLocaleDateString('en-GB', {
-          day: '2-digit',
-          month: 'short',
-          year: 'numeric',
-        })
-        .replace(/ /g, ' ');
+      const dateString = date.toLocaleDateString('en-GB', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+      });
 
       listItem.innerHTML = `
-                <span class="anomaly-score">${score}</span>
-                <span class="anomaly-text">Anomaly</span>
-                <span class="anomaly-time">${timeString} - ${dateString}</span>
-            `;
+        <span class="anomaly-score">${score}</span>
+        <span class="anomaly-text">Anomaly</span>
+        <span class="anomaly-time">${timeString} - ${dateString}</span>
+      `;
 
       recentAnomaliesElement.appendChild(listItem);
     } catch (e) {

--- a/examples/platform_ventunoq/edge-dictation-assistant/assets/app.js
+++ b/examples/platform_ventunoq/edge-dictation-assistant/assets/app.js
@@ -94,7 +94,7 @@ function closeLanguagePicker() {
  * Sets the first language as initially selected.
  */
 function renderLanguageOptions() {
-  languageOptions.innerHTML = '';
+  languageOptions.replaceChildren();
 
   LANGUAGES.forEach((language, index) => {
     const optionButton = document.createElement('button');


### PR DESCRIPTION
Fix CodeQL findings in code https://github.com/arduino/app-bricks-examples/pull/166/checks?check_run_id=81900213301:

- Replaced innerHTML-based clear with replaceChildren in the language options renderer.
- Removed a redundant replace call that replaced spaces with spaces in anomaly date formatting.