### PR TITLE
Add Basics examples manifest and tasks

### DIFF
--- a/.github/workflows/check-examples-manifest.yml
+++ b/.github/workflows/check-examples-manifest.yml
@@ -1,0 +1,33 @@
+name: Check examples manifest
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/check-examples-manifest.yml"
+      - "Taskfile.dist.yml"
+      - "scripts/examples_manifest.py"
+      - "examples.json"
+      - "core-and-foundational/**"
+      - "bricks/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-manifest:
+    runs-on: ubuntu-latest
+    env:
+      TASKFILE_VERSION: "v3.44.0"
+      TASKFILE_PATH: "/home/runner/go/bin"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Taskfile
+        run: which task || curl -sSfL https://taskfile.dev/install.sh | sh -s -- -b ${{ env.TASKFILE_PATH }} ${{ env.TASKFILE_VERSION }}
+
+      - name: Check examples manifest
+        run: |
+          export PATH="${{ env.TASKFILE_PATH }}:$PATH"
+          task examples:check-manifest

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Available tasks:
 
 The REUSE virtualenv is recreated and cleaned up automatically. The `.venv` used by `licensed` is kept after the task completes and recreated on the next dependency-license run.
 
+#### Examples manifest
+
+This project ships an [examples.json](./examples.json) manifest describing the core-and-foundational and bricks examples. The file is fully derived from the filesystem and must stay in sync with it: a CI check fails any pull request where the manifest is stale.
+
+Available tasks:
+
+- `task examples:gen-manifest` — regenerate `examples.json` from the filesystem.
+- `task examples:check-manifest` — fail when `examples.json` does not match the filesystem.
+
+After adding, removing or renaming an example, run `task examples:gen-manifest` and commit the updated manifest.
+
 #### Code formatting
 
 This project uses [ESLint](https://eslint.org/), [Prettier](https://prettier.io/), and Ruff to maintain consistent code style.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -130,6 +130,7 @@ path = [
   "eslint.config.mjs",
   "REUSE.toml",
   "ruff.toml",
+  "examples.json",
 ]
 SPDX-FileCopyrightText = "Copyright (C) Arduino s.r.l. and/or its affiliated companies"
 SPDX-License-Identifier = "CC0-1.0"

--- a/Taskfile.dist.yml
+++ b/Taskfile.dist.yml
@@ -47,6 +47,16 @@ tasks:
     cmds:
       - task: license:init-venvs
 
+  examples:gen-manifest:
+    desc: Generate examples.json from the filesystem
+    cmds:
+      - python3 scripts/examples_manifest.py --write
+
+  examples:check-manifest:
+    desc: Fail when examples.json does not match the filesystem
+    cmds:
+      - python3 scripts/examples_manifest.py --check
+
   install-bricks:
     desc: Install a specific bricks version (e.g. task install-bricks -- 0.8.0rc2)
     cmds:

--- a/examples.json
+++ b/examples.json
@@ -1,0 +1,542 @@
+{
+  "core-and-foundational": [
+    {
+      "category": "01-led-blink",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/01-led-blink/01-blinking-an-LED-mcu"
+        },
+        {
+          "id": "examples:core-and-foundational/01-led-blink/02-blinking-an-LED-MPU"
+        },
+        {
+          "id": "examples:core-and-foundational/01-led-blink/03-blinking-an-led-from-python"
+        },
+        {
+          "id": "examples:core-and-foundational/01-led-blink/04-blinking-an-led-with-ui"
+        }
+      ]
+    },
+    {
+      "category": "02-led-matrix",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/02-led-matrix/01-led-matrix-frame-mcu"
+        },
+        {
+          "id": "examples:core-and-foundational/02-led-matrix/02-led-matrix-frame"
+        },
+        {
+          "id": "examples:core-and-foundational/02-led-matrix/03-led-matrix-animation-mcu"
+        }
+      ]
+    },
+    {
+      "category": "03-bridge-basics",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/03-bridge-basics/01-call-sketch-function-from-python"
+        },
+        {
+          "id": "examples:core-and-foundational/03-bridge-basics/02-send-data-to-python"
+        },
+        {
+          "id": "examples:core-and-foundational/03-bridge-basics/03-using-structured-data"
+        }
+      ]
+    },
+    {
+      "category": "04-logging",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/04-logging/01-logger"
+        },
+        {
+          "id": "examples:core-and-foundational/04-logging/02-mcu-monitor"
+        }
+      ]
+    },
+    {
+      "category": "05-apps-basics",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/05-apps-basics/01-app-register-and-start-bricks"
+        },
+        {
+          "id": "examples:core-and-foundational/05-apps-basics/02-app-run"
+        },
+        {
+          "id": "examples:core-and-foundational/05-apps-basics/03-app-user-loop"
+        }
+      ]
+    },
+    {
+      "category": "06-camera-basics",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/06-camera-basics/01-simple-camera"
+        },
+        {
+          "id": "examples:core-and-foundational/06-camera-basics/02-camera-from-sources"
+        },
+        {
+          "id": "examples:core-and-foundational/06-camera-basics/03-camera-adjustments"
+        },
+        {
+          "id": "examples:core-and-foundational/06-camera-basics/04-record-camera-stream"
+        },
+        {
+          "id": "examples:core-and-foundational/06-camera-basics/05-websocket-camera"
+        }
+      ]
+    },
+    {
+      "category": "07-microphone-basics",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/07-microphone-basics/01-recording-from-microphone-and-file-save"
+        },
+        {
+          "id": "examples:core-and-foundational/07-microphone-basics/02-microphone-capture-and-stream"
+        },
+        {
+          "id": "examples:core-and-foundational/07-microphone-basics/03-microphone-and-properties"
+        }
+      ]
+    },
+    {
+      "category": "08-web-ui-basics",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/08-web-ui-basics/01-static-page"
+        },
+        {
+          "id": "examples:core-and-foundational/08-web-ui-basics/02-data-transmission"
+        },
+        {
+          "id": "examples:core-and-foundational/08-web-ui-basics/03-button-action"
+        },
+        {
+          "id": "examples:core-and-foundational/08-web-ui-basics/04-https-web-ui"
+        },
+        {
+          "id": "examples:core-and-foundational/08-web-ui-basics/05-web-ui-camera-stream"
+        }
+      ]
+    },
+    {
+      "category": "09-computer-vision",
+      "examples": [
+        {
+          "id": "examples:core-and-foundational/09-computer-vision/01-simple-object-detection"
+        },
+        {
+          "id": "examples:core-and-foundational/09-computer-vision/02-video-object-detection"
+        },
+        {
+          "id": "examples:core-and-foundational/09-computer-vision/03-image-classification-trigger"
+        },
+        {
+          "id": "examples:core-and-foundational/09-computer-vision/04-object-detection-with-ui"
+        }
+      ]
+    }
+  ],
+  "bricks": [
+    {
+      "brick": "arduino:air_quality_monitoring",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/air_quality_monitoring/01_get_air_quality_by_city"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:arduino_cloud",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/arduino_cloud/01_led_blink"
+        },
+        {
+          "id": "examples:bricks/arduino/arduino_cloud/02_light_with_colors_monitor"
+        },
+        {
+          "id": "examples:bricks/arduino/arduino_cloud/03_light_with_colors_command"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:asr",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/asr/01_transcribe_wav"
+        },
+        {
+          "id": "examples:bricks/arduino/asr/02_stream_wav_transcription"
+        },
+        {
+          "id": "examples:bricks/arduino/asr/03_transcribe_mic"
+        },
+        {
+          "id": "examples:bricks/arduino/asr/04_stream_mic_transcription"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:audio_classification",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/audio_classification/01_glass_breaking_from_file"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:camera_code_detection",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/camera_code_detection/01_detection"
+        },
+        {
+          "id": "examples:bricks/arduino/camera_code_detection/02_detection_list"
+        },
+        {
+          "id": "examples:bricks/arduino/camera_code_detection/03_detection_with_overrides"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:cloud_asr",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/cloud_asr/01_asr"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_asr/02_multilingual_asr"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_asr/03_event_stream"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_asr/04_different_providers"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:cloud_llm",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/cloud_llm/01_simple_prompt"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_llm/02_streaming_responses"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_llm/03_no_memory"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_llm/04_model_selection"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_llm/05_tool_calling"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_llm/06_multimodal"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_llm/07_external_provider"
+        },
+        {
+          "id": "examples:bricks/arduino/cloud_llm/08_persistent_memory"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:dbstorage_sqlstore",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/dbstorage_sqlstore/01_store_and_read_example"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:dbstorage_tsstore",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/dbstorage_tsstore/01_write_read"
+        },
+        {
+          "id": "examples:bricks/arduino/dbstorage_tsstore/02_read_all_samples"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:gesture_recognition",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/gesture_recognition/01_gesture"
+        },
+        {
+          "id": "examples:bricks/arduino/gesture_recognition/02_enter_exit"
+        },
+        {
+          "id": "examples:bricks/arduino/gesture_recognition/03_confirm_deny"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:image_classification",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/image_classification/01_image_classification_example"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:keyword_spotting",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/keyword_spotting/01_hello_world"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:llm",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/llm/01_simple_chat"
+        },
+        {
+          "id": "examples:bricks/arduino/llm/02_simple_streaming_chat"
+        },
+        {
+          "id": "examples:bricks/arduino/llm/03_select_model_streaming_chat"
+        },
+        {
+          "id": "examples:bricks/arduino/llm/04_tool_calling"
+        },
+        {
+          "id": "examples:bricks/arduino/llm/05_streaming_with_tools"
+        },
+        {
+          "id": "examples:bricks/arduino/llm/06_persistent_memory"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:mood_detector",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/mood_detector/01_basic_usage"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:motion_detection",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/motion_detection/01_basic_usage"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:object_detection",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/object_detection/01_object_detection_example"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:sound_generator",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/sound_generator/01_play_sequence"
+        },
+        {
+          "id": "examples:bricks/arduino/sound_generator/02_stream_sequence"
+        },
+        {
+          "id": "examples:bricks/arduino/sound_generator/03_play_abc_notation"
+        },
+        {
+          "id": "examples:bricks/arduino/sound_generator/04_effects"
+        },
+        {
+          "id": "examples:bricks/arduino/sound_generator/05_play_chords"
+        },
+        {
+          "id": "examples:bricks/arduino/sound_generator/06_play_polyphonic"
+        },
+        {
+          "id": "examples:bricks/arduino/sound_generator/07_play_step_sequence"
+        },
+        {
+          "id": "examples:bricks/arduino/sound_generator/08_play_composition"
+        },
+        {
+          "id": "examples:bricks/arduino/sound_generator/09_play_wav"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:streamlit_ui",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/streamlit_ui/01_basic_usage"
+        },
+        {
+          "id": "examples:bricks/arduino/streamlit_ui/02_using_other_bricks"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:telegram_bot",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/telegram_bot/01_text_echo"
+        },
+        {
+          "id": "examples:bricks/arduino/telegram_bot/02_command_handler"
+        },
+        {
+          "id": "examples:bricks/arduino/telegram_bot/03_whitelist_auth"
+        },
+        {
+          "id": "examples:bricks/arduino/telegram_bot/04_scheduled_messages"
+        },
+        {
+          "id": "examples:bricks/arduino/telegram_bot/05_photo_echo"
+        },
+        {
+          "id": "examples:bricks/arduino/telegram_bot/06_audio_echo"
+        },
+        {
+          "id": "examples:bricks/arduino/telegram_bot/07_video_echo"
+        },
+        {
+          "id": "examples:bricks/arduino/telegram_bot/08_document_echo"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:tts",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/tts/01_speak_through_speaker"
+        },
+        {
+          "id": "examples:bricks/arduino/tts/02_synthesize_wav"
+        },
+        {
+          "id": "examples:bricks/arduino/tts/03_synthesize_pcm"
+        },
+        {
+          "id": "examples:bricks/arduino/tts/04_synthesize_pcm_stream"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:vibration_anomaly_detection",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/vibration_anomaly_detection/01_basic_usage"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:video_imageclassification",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/video_imageclassification/01_basic_usage"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:video_objectdetection",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/video_objectdetection/01_basic_usage"
+        },
+        {
+          "id": "examples:bricks/arduino/video_objectdetection/02_count_objects"
+        },
+        {
+          "id": "examples:bricks/arduino/video_objectdetection/03_get_image"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:visual_anomaly_detection",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/visual_anomaly_detection/01_visual_anomaly_example"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:vlm",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/vlm/01_simple_chat"
+        },
+        {
+          "id": "examples:bricks/arduino/vlm/02_simple_streaming_chat"
+        },
+        {
+          "id": "examples:bricks/arduino/vlm/03_persistent_memory"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:wave_generator",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/wave_generator/01_basic_tone"
+        },
+        {
+          "id": "examples:bricks/arduino/wave_generator/02_waveform_types"
+        },
+        {
+          "id": "examples:bricks/arduino/wave_generator/03_frequency_sweep"
+        },
+        {
+          "id": "examples:bricks/arduino/wave_generator/04_envelope_control"
+        },
+        {
+          "id": "examples:bricks/arduino/wave_generator/05_custom_speaker"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:weather_forecast",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/weather_forecast/01_weather_forecast_by_city_example"
+        },
+        {
+          "id": "examples:bricks/arduino/weather_forecast/02_weather_forecast_by_coords_example"
+        }
+      ]
+    },
+    {
+      "brick": "arduino:web_ui",
+      "examples": [
+        {
+          "id": "examples:bricks/arduino/web_ui/01_serve_webapp"
+        },
+        {
+          "id": "examples:bricks/arduino/web_ui/02_serve_webapp_and_api"
+        },
+        {
+          "id": "examples:bricks/arduino/web_ui/03_connect_disconnect"
+        },
+        {
+          "id": "examples:bricks/arduino/web_ui/04_on_message"
+        },
+        {
+          "id": "examples:bricks/arduino/web_ui/05_send_message"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/examples_manifest.py
+++ b/scripts/examples_manifest.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (C) Arduino s.r.l. and/or its affiliated companies
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""Generate or check the examples manifest (examples.json).
+
+The manifest is fully derived from the filesystem:
+- core-and-foundational: one entry per category folder (NN- prefixes define the
+  order), each holding its examples in folder order.
+- bricks: one entry per brick (A-Z), each holding its examples in folder order.
+
+An example is a directory containing an app.yaml file. Example IDs are the
+`examples:` namespace prefix followed by the example path relative to the
+repository root.
+
+Usage:
+    python3 scripts/examples_manifest.py --write   # (re)generate examples.json
+    python3 scripts/examples_manifest.py --check   # fail if examples.json is stale
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+MANIFEST = "examples.json"
+CORE_ROOT = "core-and-foundational"
+BRICKS_ROOT = "bricks"
+
+
+def is_example(path: Path) -> bool:
+    return path.is_dir() and (path / "app.yaml").is_file()
+
+
+def example_entry(path: Path) -> dict:
+    return {"id": f"examples:{path.as_posix()}"}
+
+
+def core_section(repo: Path) -> list:
+    root = repo / CORE_ROOT
+    section = []
+    for category in sorted(p for p in root.iterdir() if p.is_dir()):
+        examples = [example_entry(p.relative_to(repo)) for p in sorted(category.iterdir()) if is_example(p)]
+        if examples:
+            section.append({"category": category.name, "examples": examples})
+    return section
+
+
+def bricks_section(repo: Path) -> list:
+    root = repo / BRICKS_ROOT
+    section = []
+    for namespace in sorted(p for p in root.iterdir() if p.is_dir()):
+        for brick in sorted(p for p in namespace.iterdir() if p.is_dir()):
+            examples = [example_entry(p.relative_to(repo)) for p in sorted(brick.iterdir()) if is_example(p)]
+            if examples:
+                section.append({"brick": f"{namespace.name}:{brick.name}", "examples": examples})
+    return section
+
+
+def render(repo: Path) -> str:
+    manifest = {
+        "core-and-foundational": core_section(repo),
+        "bricks": bricks_section(repo),
+    }
+    return json.dumps(manifest, indent=2) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--write", action="store_true", help="write the manifest to examples.json")
+    mode.add_argument("--check", action="store_true", help="fail when examples.json does not match the filesystem")
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parent.parent
+    expected = render(repo)
+    manifest_path = repo / MANIFEST
+
+    if args.write:
+        manifest_path.write_text(expected)
+        print(f"{MANIFEST} written.")
+        return 0
+
+    if not manifest_path.is_file():
+        print(f"::error::{MANIFEST} is missing. Run 'task examples:gen-manifest' and commit the result.")
+        return 1
+    if manifest_path.read_text() != expected:
+        print(f"::error::{MANIFEST} is out of date. Run 'task examples:gen-manifest' and commit the result.")
+        return 1
+    print(f"{MANIFEST} is up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR adds:
- two tasks:
  - `task examples:gen-manifest`
  - `task examples:check-manifest`
- a CI check that calls `task examples:check-manifest` and fails if the manifest is out-of-date
- The `examples.json` manifest for Basics Examples section