### PR TITLE
fix: fix led matrix cell deletion

### DIFF
--- a/inspirational/common/led-matrix-painter/assets/app.js
+++ b/inspirational/common/led-matrix-painter/assets/app.js
@@ -1050,7 +1050,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const cell = e.target;
     const brightness = brightnessAlphaSlider.value;
 
-    if (brightness === '0') {
+    if (brightness === cell.dataset.b || '') {
       delete cell.dataset.b;
     } else {
       cell.dataset.b = brightness;


### PR DESCRIPTION
Clicking on an already-painted cell now toggles it off (deselects it), instead of requiring the eraser tool. The fix corrects the brightness comparison logic: previously a type mismatch between string and integer prevented the toggle from working correctly.