### PR TITLE
fix: CloudLLM model argument in bricks examples

### DIFF
--- a/bricks/arduino/cloud_llm/04_model_selection/python/main.py
+++ b/bricks/arduino/cloud_llm/04_model_selection/python/main.py
@@ -2,11 +2,11 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from arduino.app_bricks.cloud_llm import CloudLLM
+from arduino.app_bricks.cloud_llm import CloudLLM, CloudModel
 from arduino.app_utils import App
 
 llm = CloudLLM(
-    model="google:gemini-2.5-flash",  # or CloudModel.GOOGLE_GEMINI
+    model=CloudModel.GOOGLE_GEMINI,
     api_key="YOUR_API_KEY",  # Replace with your actual API key
 )
 

--- a/bricks/arduino/cloud_llm/05_tool_calling/python/main.py
+++ b/bricks/arduino/cloud_llm/05_tool_calling/python/main.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from arduino.app_bricks.cloud_llm import CloudLLM, tool
+from arduino.app_bricks.cloud_llm import CloudLLM, CloudModel, tool
 from arduino.app_utils import App
 
 
@@ -23,7 +23,7 @@ def get_current_weather(location: str) -> str:
 
 
 llm = CloudLLM(
-    model="google:gemini-2.5-flash",
+    model=CloudModel.GOOGLE_GEMINI,
     api_key="YOUR_API_KEY",  # Replace with your actual API key
     tools=[get_current_weather],
 )


### PR DESCRIPTION
This PR fix model definition for CloudLLM bricks examples so it will not be necessary to mantain the model name anymore if the model will not be available in future using `CloudModel` class.