### PR TITLE
Fix: turn off LED after initialization in Cloud Blink example

### DIFF
--- a/inspirational/common/cloud-blink/sketch/sketch.ino
+++ b/inspirational/common/cloud-blink/sketch/sketch.ino
@@ -6,6 +6,7 @@
 
 void setup() {
     pinMode(LED_BUILTIN, OUTPUT);
+    digitalWrite(LED_BUILTIN, HIGH); // Ensure the LED starts off (the LED is active-low)
 
     Bridge.begin();
     Bridge.provide("set_led_state", set_led_state);


### PR DESCRIPTION
After initialization, the LED_BUILTIN  is on even if the initial state is reported as "False" to Arduino IoT Cloud. 
This fix sets the initial LED state to off.