### PR TITLE
fix: examples annotations alignment

### DIFF
--- a/bricks/arduino/vibration_anomaly_detection/01_basic_usage/python/main.py
+++ b/bricks/arduino/vibration_anomaly_detection/01_basic_usage/python/main.py
@@ -12,7 +12,7 @@ vibration = VibrationAnomalyDetection(anomaly_detection_threshold=1.0)
 
 
 # Register the callback to run when an anomaly is detected
-def on_detected_anomaly(anomaly_score: float, classification: dict = None):
+def on_detected_anomaly(anomaly_score: float, classification: dict | None = None):
     print(f"[Anomaly] score={anomaly_score:.3f}")
 
 

--- a/bricks/arduino/vibration_anomaly_detection/01_basic_usage/python/main.py
+++ b/bricks/arduino/vibration_anomaly_detection/01_basic_usage/python/main.py
@@ -11,7 +11,9 @@ logger = Logger("Vibration Anomaly Example")
 vibration = VibrationAnomalyDetection(anomaly_detection_threshold=1.0)
 
 
-# Register the callback to run when an anomaly is detected
+# Register the callback to run when an anomaly is detected.
+# `classification` holds the label scores of the auxiliary classification head when the model has one,
+# None otherwise: keep the parameter optional so the callback works with both kinds of model.
 def on_detected_anomaly(anomaly_score: float, classification: dict | None = None):
     print(f"[Anomaly] score={anomaly_score:.3f}")
 

--- a/bricks/arduino/video_object_detection/03_get_image/python/main.py
+++ b/bricks/arduino/video_object_detection/03_get_image/python/main.py
@@ -11,7 +11,7 @@ video_detector = VideoObjectDetection(confidence=0.4, camera_preview=True)
 
 
 # Callback for all detections (must take one dict argument for detections and one bytes argument for the camera preview frame)
-def on_all_detections(detections: dict, frame: bytes):
+def on_all_detections(detections: dict, frame: bytes | None):
     print("All detections:", detections)
     if frame is None:
         return

--- a/bricks/arduino/video_object_detection/03_get_image/python/main.py
+++ b/bricks/arduino/video_object_detection/03_get_image/python/main.py
@@ -10,7 +10,8 @@ from arduino.app_bricks.video_objectdetection import VideoObjectDetection
 video_detector = VideoObjectDetection(confidence=0.4, camera_preview=True)
 
 
-# Callback for all detections (must take one dict argument for detections and one bytes argument for the camera preview frame)
+# Callback for all detections: one dict argument for the detections and one `frame` argument for the camera
+# preview frame as JPEG bytes, which is None when no preview frame is available yet (or camera_preview is off)
 def on_all_detections(detections: dict, frame: bytes | None):
     print("All detections:", detections)
     if frame is None:

--- a/bricks/arduino/video_object_detection/03_get_image/python/main.py
+++ b/bricks/arduino/video_object_detection/03_get_image/python/main.py
@@ -16,9 +16,13 @@ def on_all_detections(detections: dict, frame: bytes | None):
     if frame is None:
         return
     image_with_bb = draw_bounding_boxes(frame, detections)
+    image_bytes = get_image_bytes(image_with_bb)
+    if image_bytes is None:
+        print("Could not encode the annotated frame")
+        return
     # Do something with the image with bounding boxes (e.g., save it, etc.)
     with open("/app/latest_frame_with_detections.jpg", "wb") as f:
-        f.write(get_image_bytes(image_with_bb))
+        f.write(image_bytes)
 
 
 video_detector.on_detect_all(on_all_detections)

--- a/core-and-foundational/06-camera-basics/01-simple-camera/python/main.py
+++ b/core-and-foundational/06-camera-basics/01-simple-camera/python/main.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Example app to capture an image from the camera and it stores it to the local storage.
-import numpy as np
 from arduino.app_peripherals.camera import Camera  # Import the Camera class to interact with the camera peripheral
 from arduino.app_utils import App
 from arduino.app_utils.image import compress_to_jpeg  # Import the compress_to_jpeg function to compress images to JPEG format
@@ -13,13 +12,15 @@ from arduino.app_utils.image import compress_to_jpeg  # Import the compress_to_j
 # If no camera is found, an exception will be raised.
 camera = Camera(resolution=(640, 480))
 camera.start()                                  # Start the camera to begin capturing images
-image: np.ndarray = camera.capture()            # Capture a raw image from the camera
-imageJpeg = compress_to_jpeg(frame=image, quality=100)
-
-if imageJpeg is not None:
-    imageBytes = imageJpeg.tobytes()
-    with open("captured_image.jpg", "wb") as f:
-        f.write(imageBytes)                     # Write the JPEG image bytes to the file
+image = camera.capture()                        # Capture a raw image from the camera (None if no frame is available)
+if image is None:
+    print("No frame captured from the camera")
+else:
+    imageJpeg = compress_to_jpeg(frame=image, quality=100)
+    if imageJpeg is not None:
+        imageBytes = imageJpeg.tobytes()
+        with open("captured_image.jpg", "wb") as f:
+            f.write(imageBytes)                     # Write the JPEG image bytes to the file
 
 camera.stop()                                   # Stop the camera
 

--- a/core-and-foundational/06-camera-basics/02-camera-from-sources/python/main.py
+++ b/core-and-foundational/06-camera-basics/02-camera-from-sources/python/main.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Example app to capture an image from the different camera sources and it stores it to the local storage.
-import numpy as np
 from arduino.app_peripherals.camera import Camera
 from arduino.app_utils import App
 from arduino.app_utils.image import compress_to_jpeg
@@ -19,13 +18,15 @@ camera = Camera("csi:0", resolution=(640, 480), fps=30) # CSI camera with positi
 #camera = Camera("http://<IP_ADDRESS>/video.mp4")  # HTTP camera, replace with the actual HTTP URL of the camera to get thestream
 
 camera.start()
-image: np.ndarray = camera.capture()
-imageJpeg = compress_to_jpeg(frame=image, quality=100)
-
-if imageJpeg is not None:
-    imageBytes = imageJpeg.tobytes()
-    with open("captured_image.jpg", "wb") as f:
-        f.write(imageBytes)
+image = camera.capture()  # Capture a raw image from the camera (None if no frame is available)
+if image is None:
+    print("No frame captured from the camera")
+else:
+    imageJpeg = compress_to_jpeg(frame=image, quality=100)
+    if imageJpeg is not None:
+        imageBytes = imageJpeg.tobytes()
+        with open("captured_image.jpg", "wb") as f:
+            f.write(imageBytes)
 
 camera.stop()
 

--- a/core-and-foundational/06-camera-basics/03-camera-adjustments/python/main.py
+++ b/core-and-foundational/06-camera-basics/03-camera-adjustments/python/main.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Example app to capture an image from the camera, apply basic transformations, and store it to the local storage.
-import numpy as np
 from arduino.app_peripherals.camera import Camera # Import the Camera class to interact with the camera peripheral
 from arduino.app_utils import App
 from arduino.app_utils.image import compress_to_jpeg # Import the compress_to_jpeg function to compress images to JPEG format
@@ -24,13 +23,15 @@ camera = Camera(resolution=(640, 480), adjustments=greyscaled() | flipped_h()) #
 #camera = Camera(resolution=(640, 480), adjustments=adjusted(brightness=0.15, contrast=1.2)) # Adjust brightness and contrast
 
 camera.start()
-image: np.ndarray = camera.capture()
-imageJpeg = compress_to_jpeg(frame=image, quality=100)
-
-if imageJpeg is not None:
-    imageBytes = imageJpeg.tobytes()
-    with open("captured_image.jpg", "wb") as f:
-        f.write(imageBytes)
+image = camera.capture()  # Capture a raw image from the camera (None if no frame is available)
+if image is None:
+    print("No frame captured from the camera")
+else:
+    imageJpeg = compress_to_jpeg(frame=image, quality=100)
+    if imageJpeg is not None:
+        imageBytes = imageJpeg.tobytes()
+        with open("captured_image.jpg", "wb") as f:
+            f.write(imageBytes)
 
 camera.stop()
 

--- a/core-and-foundational/07-microphone-basics/03-microphone-and-properties/python/main.py
+++ b/core-and-foundational/07-microphone-basics/03-microphone-and-properties/python/main.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-from arduino.app_peripherals.microphone import Microphone
+from arduino.app_peripherals.microphone import Microphone, BaseMicrophone, ALSAMicrophone
 from arduino.app_utils import App
 
 
 # This function is a helper to print the main properties of a microphone instance in the Python console.
-def print_microphone_properties(microphone: Microphone):
-    print(f"- resolved_device: {microphone.device_stable_ref}")
+# Microphone() returns the implementation matching the requested device (e.g. ALSAMicrophone for local
+# microphones), so the common interface to annotate is BaseMicrophone.
+def print_microphone_properties(microphone: BaseMicrophone):
     print(f"- name: {microphone.name}")
     print(f"- sample_rate: {microphone.sample_rate} Hz")
     print(f"- channels: {microphone.channels}")
@@ -16,7 +17,10 @@ def print_microphone_properties(microphone: Microphone):
     print(f"- buffer_size: {microphone.buffer_size} frames")
     print(f"- volume: {microphone.volume}%")
     print(f"- is_started: {microphone.is_started()}")
-    print(f"- shared: {microphone.shared}")
+    if isinstance(microphone, ALSAMicrophone):
+        # Properties specific to local (ALSA) microphones
+        print(f"- resolved_device: {microphone.device_stable_ref}")
+        print(f"- shared: {microphone.shared}")
 
 # 1. === The simplest case to create a Microhone instance with default settings =======================================
 

--- a/inspirational/common/led-matrix-painter/python/app_frame.py
+++ b/inspirational/common/led-matrix-painter/python/app_frame.py
@@ -63,9 +63,9 @@ class AppFrame(Frame):
     """
     def __init__(
             self,
-            id: int,
+            id: int | None,
             name: str,
-            position: int,
+            position: int | None,
             duration_ms: int,
             arr,
             brightness_levels: int = 256
@@ -77,9 +77,9 @@ class AppFrame(Frame):
             brightness_levels (int): Number of brightness levels (default 256).
 
         Attributes:
-            id (int): database ID of the frame.
-            name (str): user-defined name of the frame.
-            position (int): user-defined position/order of the frame.
+            id (int | None): database ID of the frame, None until the frame is saved.
+            name (str): user-defined name of the frame, empty until the backend assigns one.
+            position (int | None): user-defined position/order of the frame, None to append it.
             duration_ms (int): duration in milliseconds for animated frames.
         """
         super().__init__(arr, brightness_levels=brightness_levels)  # Initialize base Frame attributes
@@ -99,11 +99,11 @@ class AppFrame(Frame):
         for DB records.
         """
         id = data.get('id')
-        name = data.get('name')
+        name = data.get('name') or ""
         position = data.get('position')
-        duration_ms = data.get('duration_ms')
-        rows = data.get('rows')
-        brightness_levels = data.get('brightness_levels')
+        duration_ms = int(data.get('duration_ms') or 1000)
+        rows = data['rows']
+        brightness_levels = int(data.get('brightness_levels') or 256)
         return cls.from_rows(id, name, position, duration_ms, rows, brightness_levels=brightness_levels)
 
     def to_json(self) -> dict:
@@ -122,12 +122,12 @@ class AppFrame(Frame):
     @classmethod
     def from_record(cls, record: dict) -> "AppFrame":
         """Reconstruct an AppFrame from a database record dict."""
-        id = record.get('id')
-        name = record.get('name')
-        position = record.get('position')
-        duration_ms = record.get('duration_ms')
-        rows = json.loads(record.get('rows'))
-        brightness_levels = record.get('brightness_levels')
+        id = record['id']
+        name = record['name'] or ""
+        position = record['position']
+        duration_ms = int(record['duration_ms'] or 1000)
+        rows = json.loads(record['rows'])
+        brightness_levels = int(record['brightness_levels'] or 256)
         return cls.from_rows(id, name, position, duration_ms, rows, brightness_levels=brightness_levels)
 
     def to_record(self) -> dict:
@@ -228,18 +228,18 @@ class AppFrame(Frame):
     @classmethod
     def create_empty(
         cls,
-        id: int,
+        id: int | None,
         name: str,
-        position: int,
+        position: int | None,
         duration_ms: int,
         brightness_levels: int = 256,
     ) -> "AppFrame":
         """Create an empty AppFrame with all pixels set to 0.
 
         Args:
-            id (int): database ID of the frame.
+            id (int | None): database ID of the frame, None until the frame is saved.
             name (str): user-defined name of the frame.
-            position (int): user-defined position/order of the frame.
+            position (int | None): user-defined position/order of the frame, None to append it.
             duration_ms (int): duration in milliseconds for animated frames.
             width (int): width of the frame in pixels.
             height (int): height of the frame in pixels.
@@ -333,11 +333,11 @@ class AppFrame(Frame):
 
     # -- Frame.from_rows override (for subclass construction only) ---------------------------
     @classmethod
-    def from_rows(
+    def from_rows(  # type: ignore[override]
         cls,
-        id: int,
+        id: int | None,
         name: str,
-        position: int,
+        position: int | None,
         duration_ms: int,
         rows: list[list[int]] | list[str],
         brightness_levels: int = 256,
@@ -362,9 +362,9 @@ class AppFrame(Frame):
             brightness_levels (int): number of brightness levels (default 256).
 
         Attributes:
-            id (int): database ID of the frame.
+            id (int | None): database ID of the frame, None until the frame is saved.
             name (str): user-defined name of the frame.
-            position (int): user-defined position/order of the frame.
+            position (int | None): user-defined position/order of the frame, None to append it.
             duration_ms (int): duration in milliseconds for animated frames.
 
         Returns:

--- a/inspirational/common/led-matrix-painter/python/main.py
+++ b/inspirational/common/led-matrix-painter/python/main.py
@@ -220,19 +220,14 @@ def export_frames(payload: dict | None = None):
     for frame in frames:
         frame_names[frame.name] = frame_names.get(frame.name, 0) + 1
 
-    # Assign unique names if duplicates exist
-    name_counters = {}  # name -> current index
+    # Assign unique C identifiers, sanitizing the user-defined names
     for frame in frames:
         if frame_names[frame.name] > 1:
-            # Duplicate detected, add suffix
-            if frame.name not in name_counters:
-                name_counters[frame.name] = 0
-            # Use _idN suffix for uniqueness
-            frame._export_name = f"{frame.name}_id{frame.id}"
+            # Duplicate detected, use _idN suffix for uniqueness
+            frame._export_name = AppFrame._sanitize_c_ident(f"{frame.name}_id{frame.id}")
             logger.debug(f"Duplicate name '{frame.name}' -> '{frame._export_name}'")
         else:
-            # Unique name, use as-is
-            frame._export_name = frame.name
+            frame._export_name = AppFrame._sanitize_c_ident(frame.name or f"frame_{frame.id}")
 
     # Check if we're in animations mode
     animations = payload.get('animations') if payload else None

--- a/inspirational/common/led-matrix-painter/python/main.py
+++ b/inspirational/common/led-matrix-painter/python/main.py
@@ -121,6 +121,8 @@ def list_frames():
 def get_frame(payload: dict):
     """Get single frame by ID."""
     fid = payload.get('id')
+    if fid is None:
+        return {'error': 'missing id'}
     record = store.get_frame_by_id(fid)
 
     if not record:

--- a/inspirational/common/led-matrix-painter/python/main.py
+++ b/inspirational/common/led-matrix-painter/python/main.py
@@ -84,7 +84,7 @@ def bulk_update_frame_duration(payload) -> bool:
     return True
 
 
-def load_frame(payload: dict = None):
+def load_frame(payload: dict | None = None):
     """Load a frame for editing or create empty if none exist.
 
     Optional payload: {id: int} to load specific frame
@@ -193,7 +193,7 @@ def transform_frame(payload: dict):
     return {'ok': True, 'frame': frame.to_json(), 'vector': frame.to_c_string()}
 
 
-def export_frames(payload: dict = None):
+def export_frames(payload: dict | None = None):
     """Export multiple frames into a single C header string.
 
     Payload (optional): {frames: [id,...], animations: [{name, frames}]}

--- a/inspirational/common/led-matrix-painter/python/main.py
+++ b/inspirational/common/led-matrix-painter/python/main.py
@@ -214,20 +214,18 @@ def export_frames(payload: dict | None = None):
 
     logger.debug(f"Exporting {len(records)} frames to C header")
 
-    # Build frame objects and check for duplicate names
+    # Build frame objects and make their C identifiers unique. Duplicates are counted on the
+    # sanitized names (AppFrame computes them from the user-defined ones), so names that differ
+    # only by case or punctuation, e.g. "My Frame" and "my-frame", are disambiguated as well.
     frames = [AppFrame.from_record(r) for r in records]
-    frame_names = {}  # name -> count
+    export_names = {}  # sanitized name -> count
     for frame in frames:
-        frame_names[frame.name] = frame_names.get(frame.name, 0) + 1
-
-    # Assign unique C identifiers, sanitizing the user-defined names
+        export_names[frame._export_name] = export_names.get(frame._export_name, 0) + 1
     for frame in frames:
-        if frame_names[frame.name] > 1:
+        if export_names[frame._export_name] > 1:
             # Duplicate detected, use _idN suffix for uniqueness
-            frame._export_name = AppFrame._sanitize_c_ident(f"{frame.name}_id{frame.id}")
+            frame._export_name = f"{frame._export_name}_id{frame.id}"
             logger.debug(f"Duplicate name '{frame.name}' -> '{frame._export_name}'")
-        else:
-            frame._export_name = AppFrame._sanitize_c_ident(frame.name or f"frame_{frame.id}")
 
     # Check if we're in animations mode
     animations = payload.get('animations') if payload else None

--- a/inspirational/common/led-matrix-painter/python/store.py
+++ b/inspirational/common/led-matrix-painter/python/store.py
@@ -85,10 +85,12 @@ def save_frame(frame: AppFrame) -> int:
     db.store("frames", record, create_table=False)
 
     last = db.execute_sql("SELECT last_insert_rowid() as id")
-    new_id = last[0].get("id") if last else None
+    if not last or last[0].get("id") is None:
+        raise RuntimeError("Failed to retrieve the id assigned to the saved frame")
+    new_id = int(last[0]["id"])
 
     # Backend responsibility: assign progressive name if empty
-    if new_id and (not frame.name or frame.name.strip() == ''):
+    if not frame.name or frame.name.strip() == '':
         frame.name = f'Frame {new_id}'
         frame.id = new_id
         db.update("frames", {"name": frame.name}, condition=f"id = {new_id}")
@@ -143,7 +145,7 @@ def delete_frame(fid: int) -> bool:
     # Recompact positions
     rows = db.read("frames", order_by="position ASC, id ASC") or []
     for pos, r in enumerate(rows, start=1):
-        db.update("frames", {"position": pos}, condition=f"id = {int(r.get('id'))}")
+        db.update("frames", {"position": pos}, condition=f"id = {int(r['id'])}")
     return True
 
 
@@ -167,7 +169,7 @@ def delete_frames(fids: list[int]) -> bool:
     # Recompact positions
     rows = db.read("frames", order_by="position ASC, id ASC") or []
     for pos, r in enumerate(rows, start=1):
-        db.update("frames", {"position": pos}, condition=f"id = {int(r.get('id'))}")
+        db.update("frames", {"position": pos}, condition=f"id = {int(r['id'])}")
     return True
 
 

--- a/inspirational/common/music-composer/python/main.py
+++ b/inspirational/common/music-composer/python/main.py
@@ -139,9 +139,10 @@ def on_get_state(sid, data=None):
     send_state(room=sid)
 
 
-def on_update_grid(sid, data=None):
+def on_update_grid(sid, data: dict | None = None):
     """Update grid state."""
     global grid_state
+    data = data or {}
 
     if is_playing:
         logger.warning("Grid update rejected: playback in progress")
@@ -214,26 +215,29 @@ def on_stop(sid, data=None):
     send_state()
 
 
-def on_set_waveform(sid, data=None):
+def on_set_waveform(sid, data: dict | None = None):
     """Change waveform."""
     global waveform
+    data = data or {}
     waveform = data.get("waveform", "sine")
     if waveform in ["sine", "square", "triangle", "sawtooth"]:
         gen.set_wave_form(waveform)
         logger.info(f"Waveform: {waveform}")
 
 
-def on_set_volume(sid, data=None):
+def on_set_volume(sid, data: dict | None = None):
     """Change volume."""
     global volume
+    data = data or {}
     volume = data.get("volume", 80) / 100.0
     gen.set_master_volume(volume)
     logger.info(f"Volume: {volume:.2f}")
 
 
-def on_set_effects(sid, data=None):
+def on_set_effects(sid, data: dict | None = None):
     """Update effects."""
     global effects_state
+    data = data or {}
     effects_state = data.get("effects", {})
     effect_list = [SoundEffect.adsr()]
 

--- a/inspirational/common/music-composer/python/main.py
+++ b/inspirational/common/music-composer/python/main.py
@@ -142,7 +142,7 @@ def on_get_state(sid, data=None):
 def on_update_grid(sid, data: dict | None = None):
     """Update grid state."""
     global grid_state
-    data = data or {}
+    data = data or {}  # The client may emit the event without a payload
 
     if is_playing:
         logger.warning("Grid update rejected: playback in progress")
@@ -218,7 +218,7 @@ def on_stop(sid, data=None):
 def on_set_waveform(sid, data: dict | None = None):
     """Change waveform."""
     global waveform
-    data = data or {}
+    data = data or {}  # The client may emit the event without a payload
     waveform = data.get("waveform", "sine")
     if waveform in ["sine", "square", "triangle", "sawtooth"]:
         gen.set_wave_form(waveform)
@@ -228,7 +228,7 @@ def on_set_waveform(sid, data: dict | None = None):
 def on_set_volume(sid, data: dict | None = None):
     """Change volume."""
     global volume
-    data = data or {}
+    data = data or {}  # The client may emit the event without a payload
     volume = data.get("volume", 80) / 100.0
     gen.set_master_volume(volume)
     logger.info(f"Volume: {volume:.2f}")
@@ -237,7 +237,7 @@ def on_set_volume(sid, data: dict | None = None):
 def on_set_effects(sid, data: dict | None = None):
     """Update effects."""
     global effects_state
-    data = data or {}
+    data = data or {}  # The client may emit the event without a payload
     effects_state = data.get("effects", {})
     effect_list = [SoundEffect.adsr()]
 

--- a/inspirational/common/real-time-accelerometer/python/main.py
+++ b/inspirational/common/real-time-accelerometer/python/main.py
@@ -38,12 +38,11 @@ def _get_detection():
 web_ui.expose_api("GET", "/detection", _get_detection)
 
 # When a client connects, send the current detection immediately
-web_ui.on_connect(
-    lambda sid: (
-        logger.debug(f"Client connected: {sid} - sending current detection"),
-        web_ui.send_message('movement', detection_df.to_dict(orient='records')[0])
-    )
-)
+def on_client_connected(sid: str):
+    logger.debug(f"Client connected: {sid} - sending current detection")
+    web_ui.send_message('movement', detection_df.to_dict(orient='records')[0])
+
+web_ui.on_connect(on_client_connected)
 logger.debug("Registered on_connect handler for WebUI")
 
 

--- a/inspirational/common/telegram-bot/python/main.py
+++ b/inspirational/common/telegram-bot/python/main.py
@@ -38,6 +38,8 @@ def help_cmd(sender: Sender, message: Message):
 
 def sentiment(sender: Sender, message: Message):
     """Reply sentiment analysis for text messages - using convenient reply helper!"""
+    if message.text is None:
+        return  # on_text only delivers text messages, but text is optional in the Message contract
     result = mood.get_sentiment(message.text)
     sender.reply(f"Your mood is: {result}")
 
@@ -56,13 +58,16 @@ def detect_objects(
     image = Image.open(BytesIO(photo))
     results = obj_detection.detect(image, confidence=0.1)
     img_with_boxes = obj_detection.draw_bounding_boxes(image, results)
+    if results is None or img_with_boxes is None:
+        sender.reply("No objects detected")
+        return
 
     # Send result using reply_photo helper
     output = BytesIO()
     img_with_boxes.save(output, format="PNG")
     output.seek(0)
 
-    caption = f"✅ Found {len(results['detection'])} object(s)!" if results else "No objects detected"
+    caption = f"✅ Found {len(results['detection'])} object(s)!"
 
     if not sender.reply_photo(output.getvalue(), caption):
         sender.reply("❌ Failed to send processed image")

--- a/inspirational/platform_ventunoq/pose-detection/python/main.py
+++ b/inspirational/platform_ventunoq/pose-detection/python/main.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 from arduino.app_utils import App
-from arduino.app_bricks.pose_estimation import POSE_NAMES, PoseEstimation
+from arduino.app_bricks.pose_estimation import BUILTIN_POSE_NAMES, PoseEstimation
 from arduino.app_bricks.web_ui import WebUI
 
 ui = WebUI()
@@ -16,7 +16,7 @@ pose_estimation = PoseEstimation(
     out_of_frame_tolerance=0.05
 )
 
-for pose_name in POSE_NAMES:
+for pose_name in BUILTIN_POSE_NAMES:
     pose_estimation.on_pose(pose_name, lambda pose: ui.send_message("pose", {"name": pose.name, "event": pose.event}))
 
 pose_estimation.on_count_change(lambda count: ui.send_message("people", {"count": count}))


### PR DESCRIPTION
## Summary

The `check-examples-alignment` workflow of app-bricks-py reported 60 errors when analyzing these examples against the library. 34 of them are example bugs, fixed here one commit per category; the other 26 are fixed by arduino/app-bricks-py#447. Against that branch the check reports 0 errors.

## Changes

- Optional `dict` parameters declared as `dict | None` (vibration 01, led-matrix-painter).
- Callback signatures aligned with the brick contracts: `frame: bytes | None` in video detection 03, WebUI `on_connect` callback returning `None` in real-time-accelerometer.
- music-composer: handlers tolerate a missing payload (`data = data or {}`).
- `None` results of `Camera.capture`, `get_image_bytes` and `ObjectDetection.draw_bounding_boxes` are checked explicitly (camera-basics 01/02/03, video detection 03, telegram-bot).
- microphone-basics 03: the helper is annotated with `BaseMicrophone`, the common interface returned by `Microphone()`; ALSA-only properties are printed only for `ALSAMicrophone` instances.
- pose-detection: imports `BUILTIN_POSE_NAMES`, the new name of `POSE_NAMES`.
- led-matrix-painter: `AppFrame.id` and `position` are `int | None` until the backend assigns them, payload and DB fields are read with explicit defaults, `save_frame` raises if the inserted id cannot be retrieved, `get_frame` rejects a payload without id.

## Behaviour changes (all crash fixes)

- telegram-bot: the "no objects detected" path raised `AttributeError` on `None.save`; it now replies "No objects detected".
- camera-basics: a `None` frame prints a message instead of being passed to `compress_to_jpeg`.
- led-matrix-painter: a null `brightness_levels` in the payload crashed `from_rows`, now defaults to 256; the multi-frame export produced invalid C identifiers (`uint8_t Frame 1 [] = {`), names are now sanitized like in the single-frame export.

## Verification

- `check_examples_alignment.py run` against arduino/app-bricks-py#447: 0 errors.
- led-matrix-painter exercised on a VENTUNO Q through all its HTTP APIs (create, update, load, export frames and animations, delete): no errors in the logs.

## Related

- Merge arduino/app-bricks-py#447 first.
- CI follow-up adding the same check to this repository: arduino/app-bricks-examples#204.